### PR TITLE
Feat/truncate filter global & Remove components/pages which are not needed for MVP

### DIFF
--- a/components/app/landing/LandingDaoProposals.vue
+++ b/components/app/landing/LandingDaoProposals.vue
@@ -2,7 +2,7 @@
   <LandingSectionContainer class="my-32">
     <h2>{{ $t('landing.dao_proposals.title') }} <span class="text-primary">{{ $t('landing.dao_proposals.titleHighlight') }}</span></h2>
     <p>{{ $t('landing.dao_proposals.text') }}</p>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 mt-10">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-4 gap-4 mt-10">
       <div v-for="project in projects" :key="project.title">
         <NuxtLink to="/project-overview">
           <div class="shadow p-8">
@@ -14,7 +14,7 @@
                      />
               </div>
               <div>
-                <p class="text-primary p-line-head">{{project.title}}</p>
+                <p class="text-primary p-line-head">{{project.title | truncate(14)}}</p>
                 <p class="small-text">{{project.category}}</p>
               </div>
             </div>
@@ -91,23 +91,15 @@
             fundRound: '2'
           },
           {
-            title: 'DataDAO',
-            category: 'Finance',
-            projectTarget: '',
-            imageURL: require('@/assets/images/dataDao.png'),
-            startDate: '12. Nov 2021 12PM',
-            endDate: '12. Nov 2021 12PM',
-            fundRound: '2'
-          },
-          {
             title: 'Poseidon',
-            category: 'WiFi',
+            category: 'SciFi',
             projectTarget: '',
-            imageURL: require('@/assets/images/poseidon.png'),
+            imageURL: require('@/assets/images/poseidon-network.png'),
             startDate: '12. Nov 2021 12PM',
             endDate: '12. Nov 2021 12PM',
             fundRound: '2'
           },
+          
         ],
       }
     },

--- a/components/app/landing/LandingFeaturedProjectSection.vue
+++ b/components/app/landing/LandingFeaturedProjectSection.vue
@@ -38,13 +38,14 @@
                 />
               </div>
               <div>
-                <p class="text-primary thin-heading">{{ project.title }}</p>
-                <p class="small-text mt-2">{{ project.category }}</p>
+                <p class="text-primary p-line-head truncate">{{ project.title | truncate(18) }}</p>
               </div>
+              
             </div>
+            <p class="small-text mt-2 text-primary">{{ project.category }}</p>
             <div>
               <p class="small-text mt-4">
-                {{ project.description }}
+                {{ project.description | truncate(90)}}
               </p>
             </div>
             <div class="justify-self-end flex items-center mt-8">
@@ -90,15 +91,15 @@ export default {
         },
         {
           title: 'Network',
-          category: 'LoFi',
+          category: 'Finance',
           description:
             'This is a nice project. It does so nice things. And this so leave some love and like this description.',
           projectTarget: '',
           imageURL: require('@/assets/images/poseidon-network.png'),
         },
         {
-          title: 'Poseidon',
-          category: 'LoFi',
+          title: 'Poseidon Network',
+          category: 'DeFi',
           description:
             'This is a nice project. It does so nice things. And this so leave some love and like this description.',
           projectTarget: '',

--- a/components/app/landing/LandingLatestProjects.vue
+++ b/components/app/landing/LandingLatestProjects.vue
@@ -2,7 +2,7 @@
   <LandingSectionContainer class="my-32">
     <h2>{{ $t('landing.latest_projects.title') }} <span class="text-primary">{{ $t('landing.latest_projects.titleHighlight') }}</span></h2>
     <p>{{ $t('landing.latest_projects.text') }}</p>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-6 gap-4 mt-10">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5 gap-4 mt-10">
       <div v-for="project in projects" :key="project.title">
       <NuxtLink to="/project-overview">
       <div class="shadow p-4 pb-12 text-center">
@@ -11,7 +11,7 @@
             :src="project.imageURL" :alt="project.title" />
         </div>
         <div class="mt-4">
-          <p class="text-primary p-line-head">{{project.title}}</p>
+          <p class="text-primary p-line-head">{{project.title | truncate(14)}}</p>
           <p class="small-text">{{project.category}}</p>
         </div>
         <div class="mt-4 flex place-content-center">
@@ -43,7 +43,7 @@
       return {
         projects: [
           {
-            title: 'GreenSquare',
+            title: 'GreenSquareExample',
             category: 'LoFi',
             createdAt: '2h ago',
             projectTarget: '',
@@ -76,13 +76,6 @@
             createdAt: '9h ago',
             projectTarget: '',
             imageURL: require('@/assets/images/poseidon.png'),
-          },
-          {
-            title: 'Network',
-            category: 'LoFi',
-            createdAt: '1 month ago',
-            projectTarget: '',
-            imageURL: require('@/assets/images/poseidon-network.png'),
           },
         ],
       }

--- a/components/app/project-detail/ProjectSingle.vue
+++ b/components/app/project-detail/ProjectSingle.vue
@@ -130,6 +130,7 @@
     </div>
 
     <LandingSectionContainer>
+      <!--
       <h2 class="mt-16 thin-heading">
         {{ $t('project_detail.openPositions.title') }} <span class="text-primary">{{ $t('project_detail.openPositions.titleHighlight') }}</span>
       </h2>
@@ -183,7 +184,7 @@
             </div>
           </div>
         </div>
-      </div>
+      </div>-->
     </LandingSectionContainer>
   </div>
 </template>

--- a/components/app/project-overview/ProjectsHeader.vue
+++ b/components/app/project-overview/ProjectsHeader.vue
@@ -2,11 +2,14 @@
   <LandingSectionContainer>
     <h2>{{ $t('projects.header.title') }} <span class="text-primary">{{ $t('projects.header.titleHighlight') }}</span></h2>
     <p>{{ $t('projects.header.text') }}</p>
+    <!--
     <div class="flex items-center justify-between my-8">
       <ProjectsCategories />
       <ProjectsStatus />
       <ProjectsBadges /> 
+     
     </div>
+     -->
   </LandingSectionContainer>
 </template>
 

--- a/components/app/project-overview/ProjectsList.vue
+++ b/components/app/project-overview/ProjectsList.vue
@@ -2,26 +2,30 @@
   <LandingSectionContainer>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 mt-12">
     <div v-for="project in projects" :key="project.title">
+      <NuxtLink to="/project-detail">
       <div class="shadow p-2 pb-12 text-center relative">
+        <!--
         <div class="absolute top-0 right-0 mr-3 flex space-x-2">
           <img v-if="project.badgeJob" src="@/assets/images/icons/hiring-badge.svg" alt="hiring job">
           <img v-if="project.badgeFund" src="@/assets/images/icons/bitcoin-badge.svg" alt="looking for funding">
           <img v-if="project.badgeFeatured" src="@/assets/images/icons/featured-badge.svg" alt="featured project">
         </div>
+        -->
         <div class="mt-3">
           <img class="inline-block h-16 w-16 rounded-full ring-2 ring-white" :src="project.imageURL"
             :alt="project.title" />
         </div>
         <div class="mt-4">
-          <p class="text-primary p-line-head">{{project.title}}</p>
+          <p class="text-primary p-line-head">{{project.title | truncate(18)}}</p>
           <p class="small-text">{{project.category}}</p>
         </div>
         <div class="mt-6 px-3 flex place-content-center">
           <p class="small-text">
-            {{project.description}}
+            {{project.description | truncate(60)}}
           </p>
         </div>
       </div>
+      </NuxtLink>
     </div>
   </div>
   </LandingSectionContainer>
@@ -39,9 +43,9 @@
     data() {
       return {
         projects: [{
-            title: 'Jelly',
+            title: 'Jellyfreakingfish',
             category: 'LoFi',
-            description: 'This text describes the project in one pretty cool sentence.',
+            description: 'This text describes the project in one pretty cool sentence. And on and gapfillertext go with the riverflow',
             projectTarget: '',
             imageURL: require('@/assets/images/jellyfish.png'),
             badgeJob: false,
@@ -49,7 +53,7 @@
             badgeFeatured: false,
           },
           {
-            title: 'Jelly',
+            title: 'Jellyfreakingfishlowfidish',
             category: 'LoFi',
             description: 'This text describes the project in one pretty cool sentence.',
             projectTarget: '',

--- a/components/common/ButtonWithDropdown.vue
+++ b/components/common/ButtonWithDropdown.vue
@@ -18,9 +18,11 @@
             <li>
               <NuxtLink class="font-bold block px-4 py-3" to="/project-overview">{{ $t('navbar.navbarLink1') }}</NuxtLink>
             </li>
+            <!--
             <li>
               <NuxtLink class="font-bold block px-4 py-3" to="/job-overview">{{ $t('navbar.navbarLink2') }}</NuxtLink>
             </li>
+            -->
           </ul>
         </div>
     </template>

--- a/components/layout/AppNavbar.vue
+++ b/components/layout/AppNavbar.vue
@@ -10,7 +10,7 @@
         </NuxtLink>
          <div class="flex md:space-x-62px lg:space-x-128px hidden md:block">
              <NuxtLink to="/project-overview">{{ $t('navbar.navbarLink1') }}</NuxtLink>
-             <NuxtLink to="/job-overview">{{ $t('navbar.navbarLink2') }}</NuxtLink>
+             <!--<NuxtLink to="/job-overview">{{ $t('navbar.navbarLink2') }}</NuxtLink>-->
          </div>
          <div class="md:hidden"> 
            <button-with-dropdown />

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -24,7 +24,7 @@ export default {
   css: [],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: [],
+  plugins: [{ src: "~/plugins/vue-globals", ssr: true }], 
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <landing-hero-section />
-    <landing-pearl-space-section />
+    <!--<landing-pearl-space-section />-->
     <landing-featured-project-section />
     <landing-dao-proposals />
-    <landing-job-offers />
+    <!--<landing-job-offers />-->
     <landing-latest-projects />
   </div>
 </template>
@@ -12,20 +12,20 @@
 <script lang="ts">
 import Vue from 'vue'
 import LandingHeroSection from '@/components/app/landing/LandingHeroSection.vue'
-import LandingPearlSpaceSection from '@/components/app/landing/LandingPearlSpaceSection.vue'
+//import LandingPearlSpaceSection from '@/components/app/landing/LandingPearlSpaceSection.vue'
 import LandingDaoProposals from '@/components/app/landing/LandingDaoProposals.vue'
 import LandingFeaturedProjectSection from '@/components/app/landing/LandingFeaturedProjectSection.vue'
-import LandingJobOffers from '@/components/app/landing/LandingJobOffers.vue'
+//import LandingJobOffers from '@/components/app/landing/LandingJobOffers.vue'
 import LandingLatestProjects from '@/components/app/landing/LandingLatestProjects.vue'
 
 
 export default Vue.extend({
   components: {
     LandingHeroSection,
-    LandingPearlSpaceSection,
+    //LandingPearlSpaceSection,
     LandingFeaturedProjectSection,
     LandingDaoProposals,
-    LandingJobOffers,
+    //LandingJobOffers,
     LandingLatestProjects
   },
 })

--- a/plugins/vue-globals.js
+++ b/plugins/vue-globals.js
@@ -1,0 +1,8 @@
+import Vue from "vue";
+
+export default (ctx, inject) => {
+  //Global truncate filter
+  Vue.filter('truncate', function (text, stop, clamp) {
+    return text.slice(0, stop) + (stop < text.length ? clamp || '...' : '')
+  })
+}


### PR DESCRIPTION
feat(LandingDaoProposal): change grid to 4 projects and truncate title

feat(LandingFeaturedProjects): change style of cards and truncate title and description

feat(LandingLatestProjects): change grid to 5 projects and truncate title

feat(ProjectSingle): remove job offer section

feat(ProjectHeader): remove category header

feat(ProjectHeader): remove badges and truncate title and description

feat(Navbar): remove job overview from navbar

feat(Landing): remove pearl space section and job offer section on landing page