### PR TITLE
feat(DaoProjectsHeader): use date-fns to display correct countdown

### DIFF
--- a/components/app/dao-project-overview/DaoProjectsHeader.vue
+++ b/components/app/dao-project-overview/DaoProjectsHeader.vue
@@ -72,7 +72,11 @@ export default {
         },
         {
           title: this.$i18n.t('daoRoundData.countdown'),
-          daoInfo: this.daoData.metrics.endDate,
+          daoInfo: this.$dateFns.formatDistanceStrict(
+            new Date(this.daoData.metrics.endDate),
+            Date.now(),
+            { addSuffix: true, locale: this.$i18n.locale }
+          ),
           imageURL: require('@/assets/images/icons/countdown.svg'),
         },
         {


### PR DESCRIPTION
- feat(DaoProjectsHeader): use date-fns to display correct countdown

Notice: displayed text is e.g. 'in 2 days'. Maybe we need to add 'ends' to the text?