### PR TITLE
Feat/596 input components

### DIFF
--- a/components/common/AppFormControl.vue
+++ b/components/common/AppFormControl.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="form-control w-full">
+    <label class="label">
+      <slot v-if="$slots.label" name="label" />
+      <span v-else class="label-text">{{ label }}</span>
+
+      <slot v-if="$slots.altLabel" name="altLabel" />
+      <span v-else class="label-text-alt">{{ altLabel }}</span>
+    </label>
+
+    <!-- provide input element via default slot -->
+    <slot />
+
+    <label class="label">
+      <slot v-if="$slots.hint" name="hint" />
+      <span v-else class="label-text-alt">{{ hint }}</span>
+
+      <slot v-if="$slots.altHint" name="altHint" />
+      <span v-else class="label-text-alt">{{ altHint }}</span>
+    </label>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AppFormControl',
+  props: {
+    label: {
+      type: String,
+      default: null,
+    },
+    altLabel: {
+      type: String,
+      default: null,
+    },
+    hint: {
+      type: String,
+      default: null,
+    },
+    altHint: {
+      type: String,
+      default: null,
+    },
+  },
+};
+</script>

--- a/components/common/AppTextInput.vue
+++ b/components/common/AppTextInput.vue
@@ -1,0 +1,33 @@
+<template>
+  <input
+    :type="type"
+    :placeholder="placeholder"
+    :value="value"
+    :disabled="disabled"
+    class="input w-full"
+  />
+</template>
+
+<script>
+export default {
+  name: 'AppTextInput',
+  props: {
+    type: {
+      type: String,
+      default: 'text',
+    },
+    placeholder: {
+      type: String,
+      default: null,
+    },
+    value: {
+      type: String,
+      default: null,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>

--- a/components/common/AppTextarea.vue
+++ b/components/common/AppTextarea.vue
@@ -1,0 +1,28 @@
+<template>
+  <textarea
+    :placeholder="placeholder"
+    :value="value"
+    :disabled="disabled"
+    class="textarea w-full"
+  />
+</template>
+
+<script>
+export default {
+  name: 'AppTextarea',
+  props: {
+    placeholder: {
+      type: String,
+      default: null,
+    },
+    value: {
+      type: String,
+      default: null,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>


### PR DESCRIPTION
Resolve #596 

**Dependency on PR #581**

## API
- AppFormControl: Mandatory for applying labels or hints to an input field
- AppTextInput: Single text field
- AppTextarea: Textarea component

### AppFormControl Labels
- label: Top left
- altLabel: Top right
- hint: Bottom left
- altHint: Bottom right

All positions are available as vue component <kbd>props</kbd> or as <kbd>slots</kbd> for more individual usecases.

## Usage
Both <kbd>AppTextInput</kbd> and <kbd>AppTextarea</kbd> supports standalone usage without labels (AppFormControl). Otherwise the following approach should be used:

```vue
<!-- example usage -->
<app-form-control label="Label">
  <template #hint>
    <span class="text-primary">Hint text</span>
  </template>
  <app-text-input placeholder="Placeholder" v-model="..." />
</app-form-control>
```